### PR TITLE
Reorganized Victoria's Interview Notes

### DIFF
--- a/docs/research/stakeholders/interview-notes/P02-sg-mum-kids-1-and-3-notes.md
+++ b/docs/research/stakeholders/interview-notes/P02-sg-mum-kids-1-and-3-notes.md
@@ -1,4 +1,4 @@
-# Interview Notes – [Code e.g., P01 / T02 / S05]
+# Interview Notes – P02
 
 ## Participant Info
 | Field | Notes |

--- a/docs/research/stakeholders/interview-notes/P04-sg-stay-home-mum-kid-9-notes.md
+++ b/docs/research/stakeholders/interview-notes/P04-sg-stay-home-mum-kid-9-notes.md
@@ -1,4 +1,4 @@
-# Interview Notes – [Code e.g., P01 / T02 / S05]
+# Interview Notes – P04
 
 ## Participant Info
 | Field | Notes |

--- a/docs/research/stakeholders/interview-notes/P05-jp-tiktok-mum-with-keitai-notes.md
+++ b/docs/research/stakeholders/interview-notes/P05-jp-tiktok-mum-with-keitai-notes.md
@@ -1,4 +1,4 @@
-# Interview Notes – P04
+# Interview Notes – P05
 
 ## Participant Info
 | Field | Notes |

--- a/docs/research/stakeholders/interview-notes/P06-sg-stay-home-mum-kids-6-and-9-notes.md
+++ b/docs/research/stakeholders/interview-notes/P06-sg-stay-home-mum-kids-6-and-9-notes.md
@@ -1,4 +1,4 @@
-# Interview Notes – [Code e.g., P01 / T02 / S05]
+# Interview Notes – P06
 
 ## Participant Info
 | Field | Notes |

--- a/docs/research/stakeholders/interview-notes/P07-sg-working-mum-kids-6-and-9-notes.md
+++ b/docs/research/stakeholders/interview-notes/P07-sg-working-mum-kids-6-and-9-notes.md
@@ -1,4 +1,4 @@
-# Interview Notes – P05
+# Interview Notes – P07
 
 ## Participant Info
 | Field | Notes |

--- a/docs/research/stakeholders/interview-notes/P08-sg-younger-mum-kid-4-notes.md
+++ b/docs/research/stakeholders/interview-notes/P08-sg-younger-mum-kid-4-notes.md
@@ -1,4 +1,4 @@
-# Interview Notes – P06
+# Interview Notes – P08
 
 ## Participant Info
 | Field | Notes |

--- a/docs/research/stakeholders/interview-transcripts/E02-cyberlite-cofounder-transcript.md
+++ b/docs/research/stakeholders/interview-transcripts/E02-cyberlite-cofounder-transcript.md
@@ -1,3 +1,13 @@
+# Interview Transcript – E02
+
+## Participant Info
+| Field | Notes |
+|-------|--------|
+| Stakeholder type | Expert (Cybersafety Education) |
+| Age group | Adult / Founder of Cyberlite |
+| Interview date | 16th Dec 9am SGT|
+| Interviewer | @natashaannn |
+| Consent status | Recording allowed: Yes |
 
 # Key takeaways for book ready set go:
 - Wrote in 2020

--- a/docs/research/stakeholders/interview-transcripts/P01-sg-mum-kids-10-and-17-transcript.md
+++ b/docs/research/stakeholders/interview-transcripts/P01-sg-mum-kids-10-and-17-transcript.md
@@ -1,3 +1,15 @@
+# Interview Transcript – P01
+
+## Participant Info
+| Field | Notes |
+|-------|--------|
+| Stakeholder type | Parent (Mum) of children aged 10 and 17 |
+| Ethnic Background | Indian, migrated to SG due to spouse's work, currently also working in SG tech |
+| Age group | 35-45 |
+| Interview date | 3 Dec 2024 |
+| Interviewer | Natasha |
+| Consent status | Yes |
+
 # Parents Gateway
 - By MOE, not be specific school
 - Can have multiple kids registered to the app

--- a/docs/research/stakeholders/interview-transcripts/P02-sg-mum-kids-1-and-3-transcript.md
+++ b/docs/research/stakeholders/interview-transcripts/P02-sg-mum-kids-1-and-3-transcript.md
@@ -1,3 +1,5 @@
+# Interview Transcript – P02
+
 ## Participant Info
 | Field | Notes |
 |-------|--------|

--- a/docs/research/stakeholders/interview-transcripts/P05-jp-tiktok-mum-with-keitai-transcript.md
+++ b/docs/research/stakeholders/interview-transcripts/P05-jp-tiktok-mum-with-keitai-transcript.md
@@ -1,9 +1,9 @@
-# Interview Notes – P04 Japanese Parent on Tiktok With Kid with Kids Keitai
+# Interview Transcript – P04
 
 ## Participant Info
 | Field | Notes |
 |-------|--------|
-| Stakeholder type | Parent |
+| Stakeholder type | Parent, Japanese Parent on Tiktok With Kid with Kids Keitai |
 | Age group | |
 | Interview date | 18 Dec 2025 |
 | Interviewer | Natasha, Sugi |

--- a/docs/research/stakeholders/interview-transcripts/P07-sg-working-mum-6-and-9-transcript.md
+++ b/docs/research/stakeholders/interview-transcripts/P07-sg-working-mum-6-and-9-transcript.md
@@ -1,4 +1,4 @@
-# Interview Notes – P05
+# Interview Transcript – P07
 
 ## Participant Info
 | Field | Notes |

--- a/docs/research/stakeholders/interview-transcripts/P08-sg-younger-mum-kid-4-transcript.md
+++ b/docs/research/stakeholders/interview-transcripts/P08-sg-younger-mum-kid-4-transcript.md
@@ -1,3 +1,5 @@
+# Interview Transcript – P08
+
 ## Participant Info
 | Field | Notes |
 |-------|--------|

--- a/docs/research/user-personas/user-persona-anxious-screen-management-parent-P04.md
+++ b/docs/research/user-personas/user-persona-anxious-screen-management-parent-P04.md
@@ -1,0 +1,92 @@
+# User Persona – Anxious Screen-Management Parent (P04)
+
+## Basic Profile
+| Attribute | Description |
+|-----------|-------------|
+| Name | Anxious Screen-Management Parent (P04) |
+| Age | Mid 30s–40 |
+| School Level | Parent of a primary school child (around 9 years old) |
+| Tech Proficiency | Medium (uses iPad “Parenting Mode” and restrictions, but child still bypasses) |
+| Location / Community | Singapore; relies on teachers/caregivers for emergency communication |
+| Source interview notes | [P04](docs/research/stakeholders/interview-notes/P04-sg-stay-home-mum-kid-9-notes.md) |
+
+---
+
+## Background
+This persona represents a stay-at-home parent managing a 9-year-old child’s digital life primarily through home devices (iPad, Nintendo Switch). The parent wants to keep the child safe and age-appropriate online, but is repeatedly surprised by how quickly the child learns to bypass restrictions.
+
+The parent experiences frequent stress and vigilance around screen time: enforcement requires constant attention, and the child’s behavior (lying about usage, seeking loopholes) erodes trust.
+
+---
+
+## Goals & Motivations
+- Keep the child safe from inappropriate content (mature streamers, unsafe browsing, random content).
+- Maintain reasonable daily screen limits while avoiding constant conflict.
+- Preserve trust and honesty in the parent-child relationship.
+- Find healthier alternatives to screens that still keep the child engaged and occupied.
+
+---
+
+## Challenges / Pain Points
+- Child rapidly bypasses controls (e.g., shifting from YouTube Kids to browsing YouTube via the browser; using search engines like DuckDuckGo).
+- Difficulty finding truly “safe by default” experiences across apps and browsers.
+- High monitoring burden: parent feels they must constantly supervise to enforce a 30-minute limit.
+- Child shows signs of compulsive usage (struggles to self-stop until device is taken away).
+- Lack of compelling offline activities; parent struggles to identify hobbies that compete with screens.
+- Trust breakdown moments: child lies about whether they already had screen time.
+
+---
+
+## Needs from FutureNet
+| Need | Why it matters |
+|------|----------------|
+| Bounded screen time that reduces monitoring load | Parent needs short, reliable periods of safe usage without hovering or constant checking. |
+| Strong browser-level parental mode (not just app-level) | The browser becomes the loophole; safety must extend across the device, not only within “kids apps.” |
+| Age-based filtering and content classification | Prevent exposure to mature gaming/streamer content for a 9-year-old, including recommendations and search results. |
+| Parent dashboard with clear summaries | Needs visibility by app/category (YouTube, browser, games) to spot patterns and reduce anxiety. |
+| Support for trust-building routines | Helps shift from “policing” to consistent rituals (agreements, review moments, honesty incentives). |
+| Offline activity scaffolding | Suggestions and nudges to help children discover non-screen interests (arts, physical play, projects). |
+
+---
+
+## Behaviors & Digital Habits
+| Category | Notes |
+|----------|--------|
+| Time spent on devices | Daily iPad/TV time (~30 minutes) is actively enforced; gaming allowed (~1 hour/day). |
+| Favorite activities | Child gravitates to iPad video content and gaming; limited self-initiated offline play. |
+| Communication behavior | Parent expects teachers/caregivers to contact them in emergencies; child does not need direct device communication. |
+| Attention span | Child gets “stuck” in screen mode; transitions away from screens are a consistent pain point. |
+
+---
+
+## Emotional Considerations
+This parent feels anxious and tired from constant vigilance, but also deeply protective. They want to be fair and avoid over-restriction, yet repeated loopholes create a sense that “nothing works.”
+
+They feel reassured by:
+- Tools that are hard to bypass
+- Clear, simple dashboards
+- Systems that reduce daily decision fatigue
+
+---
+
+## Quotes (if interview based)
+> “It’s very hard to get her off the screen every time.”
+
+> “I don’t know how she ends up figuring out DuckDuckGo and discover all these streamers.”
+
+> “I want them not to lie to me.”
+
+---
+
+## Acceptance Criteria for Success
+FutureNet is successful for this persona if:
+- [ ] The child cannot easily bypass age controls via browsers or search.
+- [ ] The parent can allow limited screen time without constant monitoring and stress.
+- [ ] The system encourages healthier transitions off screens with fewer battles.
+- [ ] The parent gains clear visibility into what content/categories drive overuse.
+- [ ] The parent-child relationship improves (less lying, more shared agreements).
+
+---
+
+## Persona Snapshot
+**Key value proposition:** *A bypass-resistant, low-effort safety and screen-time system that gives anxious parents peace of mind, reduces daily policing, and helps children build healthier digital habits.*

--- a/docs/research/user-personas/user-persona-balanced-working-parent.md
+++ b/docs/research/user-personas/user-persona-balanced-working-parent.md
@@ -8,6 +8,7 @@
 | School Level | University-educated professional |
 | Tech Proficiency | Medium–High (uses digital tools, married to tech‑savvy husband) |
 | Location / Community | Singapore, with prior experience living in US and China |
+| Source interview notes | [P02](docs/research/stakeholders/interview-notes/P02-sg-mum-kids-1-and-3-notes.md) |
 
 ---
 

--- a/docs/research/user-personas/user-persona-digital-safety-conscious-parent.md
+++ b/docs/research/user-personas/user-persona-digital-safety-conscious-parent.md
@@ -8,6 +8,7 @@
 | School Level | University-educated (inferred from structured digital management & MOE familiarity) |
 | Tech Proficiency | Medium–High (Apple Family, apps, tracking tools, Parents Gateway) |
 | Location / Community | Singapore, with children in MOE school system |
+| Source interview notes | [P01](docs/research/stakeholders/interview-notes/P01-sg-mum-kids-10-and-17-notes.md) |
 
 ---
 

--- a/docs/research/user-personas/user-persona-japan-screen-free-safety-parent.md
+++ b/docs/research/user-personas/user-persona-japan-screen-free-safety-parent.md
@@ -8,6 +8,7 @@
 | School Level | Parent of an elementary school child (started device in Grade 1; now Grade 3) |
 | Tech Proficiency | Medium |
 | Location / Community | Japan; child walks to school; school culture expects independence and responsibility |
+| Source interview notes | [P05](docs/research/stakeholders/interview-notes/P05-jp-tiktok-mum-with-keitai-notes.md) |
 
 ---
 

--- a/docs/research/user-personas/user-persona-overwhelmed-working-parent.md
+++ b/docs/research/user-personas/user-persona-overwhelmed-working-parent.md
@@ -8,6 +8,7 @@
 | School Level | Parent of a child in Primary 4–6 (10–12) or Secondary 1–2 (13–15) |
 | Tech Proficiency | Medium |
 | Location / Community | Singapore; school WhatsApp/Telegram parent groups |
+| Source interview notes | [E01](docs/research/stakeholders/interview-notes/E01-ntt-docomo-notes.md) (inferred) |
 
 ---
 

--- a/docs/research/user-personas/user-persona-tech-savvy-safety-pragmatic-parent.md
+++ b/docs/research/user-personas/user-persona-tech-savvy-safety-pragmatic-parent.md
@@ -8,6 +8,7 @@
 | School Level | University-educated professional (software engineer) |
 | Tech Proficiency | High (iOS ecosystem, parental controls, tracking devices; informed about online platform incentives) |
 | Location / Community | Singapore, children in MOE primary school system |
+| Source interview notes | [P06](docs/research/stakeholders/interview-notes/P06-sg-stay-home-mum-kids-6-and-9-notes.md) + (original base) [P05](docs/research/stakeholders/interview-notes/P05-jp-tiktok-mum-with-keitai-notes.md) |
 
 ---
 
@@ -36,6 +37,9 @@ She is not ideologically anti-tech: she believes children eventually need exposu
 - High anxiety around chat-enabled or UGC-heavy platforms (Roblox) due to predators and uncontrolled interactions.
 - Real-world independence creates safety needs (child traveling alone; uncertainty when routes change).
 - Wary of emerging AI chat products for young children; wants evidence and safeguards before adoption.
+- School-driven tech exposure can conflict with home values (e.g., schools integrating iPads/online tools early); parent worries filters can be bypassed and critical thinking may degrade.
+- New risk category: “AI as shortcut” (e.g., kids using ChatGPT to do homework) and rising cyberbullying concerns.
+- Sibling spillover risk: older child’s access can introduce younger siblings to inappropriate content earlier than intended.
 
 ---
 
@@ -50,6 +54,8 @@ She is not ideologically anti-tech: she believes children eventually need exposu
 | Trust-centered tooling | Controls should support healthy parent-child trust (transparent monitoring expectations; review rhythms) rather than secret surveillance. |
 | Ad-minimization and content quality curation | Prefers paid/ad-free options and high-quality content standards; wants to avoid “fast, overstimulating” content patterns. |
 | Evidence-based AI safety stance | Would only consider AI features if well-tested, age-appropriate, and clearly bounded for children. |
+| School-context support (classroom-safe modes) | Needs controls that match school realities (e.g., disable messaging at school time, limit to homework sites, reduce distraction) without heavy manual policing. |
+| Sibling-aware safety controls | Needs age-differentiated access and nudges that help older kids avoid “teaching” risky content to younger siblings. |
 
 ---
 
@@ -61,6 +67,8 @@ She is not ideologically anti-tech: she believes children eventually need exposu
 | Content preferences | Netflix Kids preferred; avoids YouTube/YouTube Kids where possible; pays for YouTube Premium when needed to avoid ads. |
 | Safety routines | Uses location tracking (e.g., AirTag in bag) to monitor commuting; values reliable, low-friction setup. |
 | Parenting approach to tech | “Controlled exposure” rather than strict isolation; sees skill-building as necessary long-term. |
+| Offline structure & incentives | Uses structured offline activities (sports, chores) and reward systems to reduce defaulting to screens. |
+| Communication/location tools | Will use bounded communication tools (e.g., smartwatch for location + messaging) and may disable features at school time to prevent distraction. |
 
 ---
 

--- a/docs/research/user-personas/user-persona-trust-based-self-regulation-parent.md
+++ b/docs/research/user-personas/user-persona-trust-based-self-regulation-parent.md
@@ -8,6 +8,7 @@
 | School Level | Working professional parent of preschooler (child aged 4, turning 5) |
 | Tech Proficiency | Medium (comfortable with iPad, subscriptions, basic controls; not reliant on heavy parental control tooling) |
 | Location / Community | Singapore; navigating childcare/preschool systems; frequent public transport + family meals out |
+| Source interview notes | [P08](docs/research/stakeholders/interview-notes/P08-sg-younger-mum-kid-4-notes.md) |
 
 ---
 


### PR DESCRIPTION
Branched from #57 and added the following:
- Rebased onto main with new merges of other parent notes
- Reorganized numbering based on chronological order
- Updated  the P05 persona to include P06-specific details:
  - School-driven tech exposure conflicts (iPad in class, bypass risk, critical thinking concern)
  - “AI as shortcut” (ChatGPT homework) + cyberbullying concerns
  - Sibling spillover risk
  - Added needs: classroom-safe modes + sibling-aware controls
  - Added behaviors: offline structure/rewards + smartwatch-style bounded comms/location (incl. disabling at school time)
- Added user persona of `user-persona-anxious-screen-management-parent` from P04 interview

Closes #57 , closes #46 , closes #60