### PR TITLE
Fix: replace link image metadata from default vercel to futurenet tree

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,10 +4,41 @@ import "./globals.css";
 
 const kindleLike = Literata({ subsets: ["latin"], weight: ["400", "600"] });
 
+const metadataBaseUrl = (() => {
+  const raw = (process.env.SITE_URL ?? process.env.URL ?? process.env.NEXT_PUBLIC_SITE_URL ?? "").trim();
+  if (!raw) return undefined;
+  try {
+    return new URL(raw);
+  } catch {
+    return undefined;
+  }
+})();
+
 export const metadata: Metadata = {
   title: "FutureNet",
   description:
     "A technologist-led research initiative into the digital landscape for children, adolescents, and their parents.",
+  metadataBase: metadataBaseUrl,
+  openGraph: {
+    title: "FutureNet",
+    description:
+      "A technologist-led research initiative into the digital landscape for children, adolescents, and their parents.",
+    images: [
+      {
+        url: "/doodles/png/tree.png",
+        width: 512,
+        height: 512,
+        alt: "FutureNet",
+      },
+    ],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "FutureNet",
+    description:
+      "A technologist-led research initiative into the digital landscape for children, adolescents, and their parents.",
+    images: ["/doodles/png/tree.png"],
+  },
 };
 
 export default function RootLayout({


### PR DESCRIPTION
When sharing the link of futurenet, the image that appears is vercel's default logo. This PR replaces it with futurenet's tree logo. 